### PR TITLE
adds a post deployment pod that will install the skeleton theme for grav deployment

### DIFF
--- a/apps/samples/grav-demo/base/deployment.yaml
+++ b/apps/samples/grav-demo/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: grav-demo
-        image: clubcedille/grav:0.0.3
+        image: clubcedille/grav:0.0.4
         imagePullPolicy: Always
         ports:
         - containerPort: 80
@@ -24,14 +24,24 @@ spec:
           requests:
             memory: "256Mi"
             cpu: "10m"
-            # hugepages-2Mi: "2Mi"
           limits:
             memory: "256Mi"
             cpu: "100m"
-            # hugepages-2Mi: "2Mi"
         volumeMounts:
         - name: grav-storage
           mountPath: /var/www/html
+        readinessProbe:
+          httpGet:
+            path: / 
+            port: 80
+          initialDelaySeconds: 10
+          periodSeconds: 5
+      - name: post-init-task
+        image: clubcedille/grav-init:0.0.1
+        volumeMounts:
+        - name: grav-storage
+          mountPath: /var/www/html
+        restartPolicy: Never
       volumes:
       - name: grav-storage
         persistentVolumeClaim:


### PR DESCRIPTION
…is ready

### Description
I separated the installation of the skeleton theme for grav from the main pod since the pvc would overwrite whatever was in the persistent volume. The init-grav images will save once the skeleton in the pv only if no theme is present and after the pod is ready.

### Related Issue
#48 

### Screenshots (if appropriate)

### Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
