### PR TITLE
added branch names to gha pr actions

### DIFF
--- a/.github/workflows/request-grav.yml
+++ b/.github/workflows/request-grav.yml
@@ -78,6 +78,7 @@ jobs:
               uses: peter-evans/create-pull-request@v5
               with:
                 title: Create a GRAV website for ${{inputs.nom_club}}
+                branch: grav/${{nom_club}}
                 body: |
                     Nom du club: ${{inputs.nom_club}}
                     Domaine: ${{inputs.domaine}}

--- a/.github/workflows/request-sandbox.yml
+++ b/.github/workflows/request-sandbox.yml
@@ -28,6 +28,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           title: Create sandbox for ${{github.event.sender.login}}
+          branch: sandbox/${{github.event.sender.login}}
           body: |
             @${{github.event.sender.login}}. Once this PR is merged, you will be able to login
             to your sandbox by following these steps:


### PR DESCRIPTION
Default branch name is the same for all the ones created by PR GH action, and when it collides it force pushes... so I added a branching naming pattern that changes every PR.