### PR TITLE
add cluster role permissions for kubewall

### DIFF
--- a/apps/kubewall/base/permissions.yaml
+++ b/apps/kubewall/base/permissions.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-deployment
+rules:
+  - apiGroups: ["apps"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]

--- a/apps/kubewall/base/permissionsBinding.yaml
+++ b/apps/kubewall/base/permissionsBinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubewall-cluster-deployment
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: kubewall
+roleRef:
+  kind: ClusterRole
+  name: cluster-deployment
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
### Description
En faisant mes recherches et en regardant les logs, j'ai remarque que les erreurs avaient l'air de venir du fait que le cluster role par defaut de kubewall n'avait pas les permissions necessaires pour acceder aux ressources des clusters K8S. J'ai donc ajoute 2 YAML permettant d'ajouter des permissions a kubewall.

### Testing Procedure
Ces deux YAML sont censes rendre accessible AU MOINS le cluster ou est deploye kubewall.
Je ne sais pas si kubewall possede les droits pour acceder aux autres clusters.

### Screenshots (if appropriate)

### Checklist

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

- [ ] Requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
